### PR TITLE
Remove extra import call in main.scss for deleted file

### DIFF
--- a/public/sass/main.scss
+++ b/public/sass/main.scss
@@ -7,7 +7,6 @@
 @import "modules/animated-dots";
 
 @import "modules/icon-styles";
-@import "modules/social-icon-links";
 @import "modules/colors";
 
 // Partials


### PR DESCRIPTION
Deleted import call for `_social-icon-links`, which was refactored into other files and deleted.
