### PR TITLE
Create accent bar effect on H1 text

### DIFF
--- a/public/sass/main.scss
+++ b/public/sass/main.scss
@@ -11,6 +11,7 @@
 
 // Partials
 
+@import "partials/accent-bar";
 @import "partials/button-and-mock";
 @import "partials/appbox";
 @import "partials/circular-images";

--- a/public/sass/partials/_accent-bar.scss
+++ b/public/sass/partials/_accent-bar.scss
@@ -1,0 +1,31 @@
+// these move into a Typography or Font file
+h1 {
+  padding-bottom: 1em;  // REQUIRED for accent bar do not remove
+  position: relative;   // REQUIRED for accent bar do not remove
+  &.center-align { //this is purely for sample purposes!
+    text-align: center;
+  }
+  .accent-bar-L {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+  }
+  .accent-bar-C {
+    position: absolute;
+    bottom: 0;
+    left: 50% - 3%;
+  }
+}
+
+// these stay here
+%accent-bar {
+  background-color: black;
+  height: 0.1em;
+  width: 6%;
+}
+.accent-bar-L {
+  @extend %accent-bar;
+}
+.accent-bar-C {
+  @extend %accent-bar;
+}

--- a/public/styleguide.html
+++ b/public/styleguide.html
@@ -11,6 +11,9 @@
     <link rel="stylesheet" href="css/main.css">
   </head>
 <body>
+    <h1 class="left-align">H1 Header Text<span class="accent-bar-L"></span></h1>
+    <h1 class="center-align">H1 Header Text<span class="accent-bar-C"></span></h1>
+
 <form id="newsletter-signup" class="quickform">
   <legend>Subscribe To Newsletter</legend>
   <input type="email" placeholder="Enter your email address" name="email" id="email">


### PR DESCRIPTION
Used a span within the `<h1></h1>` tag to create an accent underline.  The file contains positioning information for the accent bar that should be moved into a Text or Typography file.
