### PR TITLE
Fix unclosed curly bracket in _flex-box.scss

### DIFF
--- a/public/sass/modules/mixins/_flex-box.scss
+++ b/public/sass/modules/mixins/_flex-box.scss
@@ -19,7 +19,7 @@
     -webkit-align-content: center;
     -ms-flex-line-pack: center;
     align-content: center;
-
+}
 
 // --- Some Amazing Features Section --- //
 // flex_wrapper works for this section.
@@ -41,3 +41,4 @@
   -webkit-flex-shrink: 0;
   flex-grow: 1;
   flex-shrink: 0;
+}


### PR DESCRIPTION
Missing curly bracket prevented Sass compile.
