### PR TITLE
Smooth scroll

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
       <ul class="menu">
         <li><a href="#home-nav">HOME</a></li>
         <li><a href="#about-nav">ABOUT</a></li>
-        <li><a href="#fearures-nav">FEATURES</a></li>
+        <li><a href="#features-nav">FEATURES</a></li>
         <li><a href="#reviews-nav">REVIEWS</a></li>
         <li><a href="#screens-nav">SCREENS</a></li>
         <li><a href="#blog-nav">BLOG</a></li>
@@ -384,6 +384,7 @@
   <script type="text/javascript" src="js/deps/unslider.min.js"></script>
   <script type="text/javascript" src="js/carousel.js"></script>
   <script type="text/javascript" src="js/video.js"></script>
+  <script type="text/javascript" src="js/smooth-scroll.js"></script>
   <script type="text/javascript" src="js/nav-search.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -210,7 +210,7 @@
       <a href="#"><span class="icon-apple"></span>iOS App Store</a>
       <form action=""><fieldset><legend>Subscribe To Newsletter</legend><input type="email" placeholder="Enter your email address"/><button type="submit">SUBMIT</button></fieldset></form>
     </section>
-    <section>
+    <section id="blog-nav">
       <h1>Discounted Pricing</h1>
       <p>Nullam id odio quis risus placerat aliquam. Cum sociis natoque penatibus et magnis dis part urient montes nascetur ridiculus mus curabitur tellus lacus.</p>
       <ul class="pricing-list">

--- a/public/index.html
+++ b/public/index.html
@@ -154,7 +154,7 @@
       </div>
     <div class="arrow-position-wrapper">
       <span class="sm-semicircular-eclipse-border"><span class="icon-quotes"></span></span>
-      <h2 class="center-align">App Reviews</h2>
+      <h2 id="reviews-nav" class="center-align">App Reviews</h2>
       <h4>Read What Our Happy Customers Are Saying</h4>
       <span class="focus-arrow">&nbsp;</span>
     </div>

--- a/public/js/smooth-scroll.js
+++ b/public/js/smooth-scroll.js
@@ -1,0 +1,18 @@
+'use strict';
+
+$('.menu a').on('click', function(e) {
+  e.preventDefault();
+  var target = this.hash;
+  var $target = $(target);
+  var targetOffset = $target.offset().top-55;
+
+  $('html, body').stop().animate({
+      'scrollTop': target.offset
+  }, 1600, 'swing', function () {
+      window.location.hash = target;
+  });
+});
+
+
+
+// Source: http://www.paulund.co.uk/smooth-scroll-to-internal-links-with-jquery

--- a/public/js/smooth-scroll.js
+++ b/public/js/smooth-scroll.js
@@ -4,15 +4,15 @@ $('.menu a').on('click', function(e) {
   e.preventDefault();
   var target = this.hash;
   var $target = $(target);
-  var targetOffset = $target.offset().top-55;
-
+  var $targetOffset = $target.offset().top-80;
+  // top-80 is for where the scroll stops
+  // offset from top by 80px
   $('html, body').stop().animate({
-      'scrollTop': target.offset
+      'scrollTop': $targetOffset
   }, 1600, 'swing', function () {
       window.location.hash = target;
   });
 });
 
 
-
-// Source: http://www.paulund.co.uk/smooth-scroll-to-internal-links-with-jquery
+// Adapted from: http://www.paulund.co.uk/smooth-scroll-to-internal-links-with-jquery


### PR DESCRIPTION
Added IDs as appropriate. #about-nav goes to the "Why Choose AppBox", skipping the section before it. #blog-nav is currently assigned to "Discounted Pricing" section for testing purposes. 

Should we consider changing the text in the <nav> so they are more inline with the actual content? Or leave them be? 
