### PR TITLE
Set media call to disappear arrows in mobile

### DIFF
--- a/public/sass/partials/_screenshots_section.scss
+++ b/public/sass/partials/_screenshots_section.scss
@@ -1,9 +1,6 @@
-
-
 .screenshot-section-wrapper {
   position: relative;
 }
-
 .screenshots {
   h1 {
     font: $head-big-medium-font;

--- a/public/sass/partials/_slick-theme.scss
+++ b/public/sass/partials/_slick-theme.scss
@@ -76,6 +76,9 @@
 
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    @media screen and (max-width: 50em) {
+        display: none;
+      } 
 }
 
 .slick-prev


### PR DESCRIPTION
Arrows under screenshots - media call to make them disappear on mobile
